### PR TITLE
Build vulkan examples

### DIFF
--- a/imgui-render-vulkan/imgui/buildfile
+++ b/imgui-render-vulkan/imgui/buildfile
@@ -1,6 +1,7 @@
 intf_libs = # Interface dependencies.
-import intf_libs += imgui%lib{imgui}
+import intf_libs += imgui%lib{imgui}  Vulkan-Hpp%lib{Vulkan-Hpp}
 impl_libs = # Implementation dependencies.
+# import impl_libs += 
 
 platform_libs =
 
@@ -14,7 +15,7 @@ switch $cxx.target.class
         }
         else
         {
-            platform_libs += vulkan-1.lib
+            platform_libs += vulkan-1.lib 
         }
     }
     case 'macos'
@@ -34,7 +35,7 @@ out_pfx_inc = [dir_path] $out_root/imgui/
 src_pfx_inc = [dir_path] $src_root/imgui/
 
 cxx.libs =+ $platform_libs
-cxx.poptions =+ "-I$out_pfx_inc" "-I$src_pfx_inc" -DIMGUI_EXPORT
+cxx.poptions =+ "-I$out_pfx_inc" "-I$src_pfx_inc" -DIMGUI_EXPORT -DVK_PROTOTYPES
 
 {hbmia obja}{*}: cxx.poptions += -DIMGUI_RENDER_VULKAN_STATIC_BUILD
 {hbmis objs}{*}: cxx.poptions += -DIMGUI_RENDER_VULKAN_SHARED_BUILD
@@ -42,7 +43,7 @@ cxx.poptions =+ "-I$out_pfx_inc" "-I$src_pfx_inc" -DIMGUI_EXPORT
 # Export options.
 lib{imgui-render-vulkan}:
 {
-    cxx.export.poptions = "-I$out_pfx_inc" "-I$src_pfx_inc"
+    cxx.export.poptions = "-I$out_pfx_inc" "-I$src_pfx_inc" -DVK_PROTOTYPES
     cxx.export.libs = $intf_libs $platform_libs
 }
 

--- a/imgui-render-vulkan/manifest
+++ b/imgui-render-vulkan/manifest
@@ -14,3 +14,6 @@ package-email: swat.somebug@gmail.com
 depends: * build2 >= 0.14.0
 depends: * bpkg >= 0.14.0
 depends: imgui == $
+depends: Vulkan-Hpp ^1.0.0
+
+


### PR DESCRIPTION
This makes vulkan examples compile and run (windows/msvc for me after installing the Vulkan SDK and making it availbalbe through `config.cc.loptions = /LIBPATH:C:/VulkanSDK/1.3.211.0/Lib` in my build config.

Unfortunately the vulkan headers packages will not themselve look for the proper library to link.
In addition, I couldn't think of a way to automatically locate the vulkan lib, it have to be provided by the environment (like I did here). I think it's ok  to expect users to have the right lib available, but it means that not all example can be built by default.
